### PR TITLE
Fix bracket group field

### DIFF
--- a/src/lib/services/match-generators/bracket.ts
+++ b/src/lib/services/match-generators/bracket.ts
@@ -1,8 +1,82 @@
-import { MatchPlan, Tournament } from '@/types'
+import {
+  MatchPlan,
+  Tournament,
+  TournamentMatch,
+  TournamentRound,
+} from '@/types'
+import { createTableMatchPlan } from './table'
 
-// TODO: Implement knockout bracket generation
+// Generate a bracket style tournament.
+// Teams are split into two groups and a table style match plan is
+// created for each group. The rounds of both groups are then
+// interleaved so that teams get as much pause as possible between
+// matches.
 export const createBracketMatchPlan = (
-  tournament: Tournament
+  tournament: Tournament,
+  maxParallelGames = 2
 ): MatchPlan => {
-  return { rounds: [], totalMatches: 0, totalRounds: 0 }
+  if (tournament.teams.length < 8) {
+    return { rounds: [], totalMatches: 0, totalRounds: 0 }
+  }
+
+  const half = Math.ceil(tournament.teams.length / 2)
+  const groupATeams = tournament.teams.slice(0, half)
+  const groupBTeams = tournament.teams.slice(half)
+
+  if (groupATeams.length < 4 || groupBTeams.length < 4) {
+    return { rounds: [], totalMatches: 0, totalRounds: 0 }
+  }
+
+  const groupAPlan = createTableMatchPlan(
+    { ...tournament, teams: groupATeams },
+    maxParallelGames,
+    'A'
+  )
+  const groupBPlan = createTableMatchPlan(
+    { ...tournament, teams: groupBTeams },
+    maxParallelGames,
+    'B'
+  )
+
+  const rounds: TournamentRound[] = []
+  let matchNumber = 1
+  const maxRounds = Math.max(groupAPlan.rounds.length, groupBPlan.rounds.length)
+
+  for (let i = 0; i < maxRounds; i++) {
+    const roundMatches: TournamentMatch[] = []
+
+    if (i < groupAPlan.rounds.length) {
+      groupAPlan.rounds[i].matches.forEach(m => {
+        roundMatches.push({
+          ...m,
+          matchNumber: matchNumber++,
+          roundNumber: rounds.length + 1,
+        })
+      })
+    }
+
+    if (i < groupBPlan.rounds.length) {
+      groupBPlan.rounds[i].matches.forEach(m => {
+        roundMatches.push({
+          ...m,
+          matchNumber: matchNumber++,
+          roundNumber: rounds.length + 1,
+        })
+      })
+    }
+
+    if (roundMatches.length > 0) {
+      rounds.push({
+        roundNumber: rounds.length + 1,
+        matches: roundMatches,
+        isComplete: false,
+      })
+    }
+  }
+
+  return {
+    rounds,
+    totalMatches: groupAPlan.totalMatches + groupBPlan.totalMatches,
+    totalRounds: rounds.length,
+  }
 }

--- a/src/lib/services/match-generators/table.ts
+++ b/src/lib/services/match-generators/table.ts
@@ -13,6 +13,7 @@ const buildMatch = (
   matchInRound: number,
   team1: TournamentTeam,
   team2: TournamentTeam,
+  tournamentGroup: string | null = null
 ): TournamentMatch => ({
   id: crypto.randomUUID(),
   tournamentId,
@@ -25,7 +26,7 @@ const buildMatch = (
   matchNumber,
   roundNumber,
   matchInRound,
-  tournamentGroup: null
+  tournamentGroup
 })
 
 const registerTeamsForRound = (
@@ -43,7 +44,8 @@ const registerTeamsForRound = (
 
 export const createTableMatchPlan = (
   tournament: Tournament,
-  maxParallelGames = 2
+  maxParallelGames = 2,
+  tournamentGroup: string | null = null
 ): MatchPlan => {
   if (tournament.teams.length < 2) {
     return { rounds: [], totalMatches: 0, totalRounds: 0 };
@@ -109,6 +111,7 @@ export const createTableMatchPlan = (
           currentRoundMatches.length + 1,
           team1,
           team2,
+          tournamentGroup
         );
 
         currentRoundMatches.push(match);
@@ -128,6 +131,7 @@ export const createTableMatchPlan = (
         1,
         team1,
         team2,
+        tournamentGroup
       );
       currentRoundMatches.push(match);
       registerTeamsForRound(team1, team2, currentRoundNumber, usedTeamsThisRound, teamLastRound);


### PR DESCRIPTION
## Summary
- ensure table generator can set a tournamentGroup for matches
- call table generator with group names inside the bracket generator

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d8cbbe6e48328aa6ddf7de48d350c